### PR TITLE
完全レガシー署名システム削除: クレームベース署名のみに統一

### DIFF
--- a/.claude/commands/pr-review/review-task-workflow.md
+++ b/.claude/commands/pr-review/review-task-workflow.md
@@ -5,6 +5,33 @@ description: Execute PR review tasks systematically using reviewtask
 
 You are tasked with executing PR review tasks systematically using the reviewtask tool. 
 
+## Available Commands:
+
+The reviewtask tool provides the following commands for managing PR review tasks:
+
+- **`reviewtask`** - Fetch latest PR reviews and generate/update tasks
+- **`reviewtask status`** - Check overall task status and get summary
+- **`reviewtask show`** - Get next recommended task based on priority
+- **`reviewtask show <task-id>`** - Show detailed information for a specific task
+- **`reviewtask update <task-id> <status>`** - Update task status
+  - Status options: `todo`, `doing`, `done`, `pending`, `cancel`
+
+### Task Completion Verification Commands:
+
+- **`reviewtask verify <task-id>`** - Run verification checks before task completion
+- **`reviewtask complete <task-id>`** - Complete task with automatic verification
+- **`reviewtask complete <task-id> --skip-verification`** - Complete task without verification
+- **`reviewtask config set-verifier <task-type> <command>`** - Configure custom verification commands
+- **`reviewtask config show`** - Display current verification configuration
+
+## Task Priority System:
+
+Tasks are automatically assigned priority levels that determine processing order:
+- **`critical`** - Security issues, critical bugs, breaking changes
+- **`high`** - Important functionality issues, major improvements
+- **`medium`** - Moderate improvements, refactoring suggestions
+- **`low`** - Minor improvements, style suggestions
+
 ## Initial Setup (Execute Once Per Command Invocation):
 
 **Fetch Latest Reviews**: Run `reviewtask` without arguments to fetch the latest PR reviews and generate/update tasks. This ensures you're working with the most current review feedback and tasks.
@@ -15,18 +42,22 @@ After completing the initial setup, follow this exact workflow:
 
 1. **Check Status**: Use `reviewtask status` to check current task status and identify any tasks in progress
    - **If all tasks are completed (no todo, doing, or pending tasks remaining)**: Stop here - all work is done!
-   - **If only pending tasks remain**: Review each pending task and decide action (see Step 2b)
+   - **If only pending tasks remain**: Review each pending task and decide action (see Step 2d)
    - **Continue only if todo, doing, or pending tasks exist**
 
 2. **Identify Task**: 
    a) **Priority order**: Always work on tasks in this order:
       - **doing** tasks first (resume interrupted work)
-      - **todo** tasks next (new work)
+      - **todo** tasks next (new work, prioritized by: critical → high → medium → low)
       - **pending** tasks last (blocked work requiring decision)
    
    b) **For doing tasks**: Continue with the task already in progress
    
-   c) **For todo tasks**: Use `reviewtask show` to get the next recommended task, then run `reviewtask update <task-id> doing`
+   c) **For todo tasks**: 
+      - First, evaluate if the task is needed using the **Task Classification Guidelines** below
+      - If needed: Use `reviewtask show` to get the next recommended task, then run `reviewtask update <task-id> doing`
+      - If duplicate/unnecessary: Update to `cancel`
+      - If uncertain: Update to `pending`
    
    d) **For pending-only scenario**: 
       - List all pending tasks and their reasons for being blocked
@@ -40,8 +71,16 @@ After completing the initial setup, follow this exact workflow:
 
 4. **Execute Task**: Implement the required changes in the current branch based on the task description and original review comment
 
-5. **Complete Task**: When implementation is finished:
-   - Mark task as completed: `reviewtask update <task-id> done`
+5. **Verify and Complete Task**: When implementation is finished:
+   a) **Verify Implementation**: Run verification checks to ensure quality:
+      - `reviewtask verify <task-id>` - Check if implementation meets verification requirements
+      - If verification fails: Review and fix issues, then retry verification
+      - If verification passes: Continue to completion
+   
+   b) **Complete Task**: Choose completion method:
+      - **Recommended**: `reviewtask complete <task-id>` - Complete with automatic verification
+      - **Alternative**: `reviewtask complete <task-id> --skip-verification` - Skip verification if needed
+      - **Manual**: `reviewtask update <task-id> done` - Direct status update (no verification)
    - Commit changes using this message template (adjust language based on `user_language` setting in `.pr-review/config.json`):
      ```
      fix: [Clear, concise description of what was fixed or implemented]
@@ -70,19 +109,149 @@ After completing the initial setup, follow this exact workflow:
      Review Comment: https://github.com/[owner]/[repo]/pull/[pr-number]#discussion_r[comment-id]
      ```
 
-6. **Continue Workflow**: After committing:
+6. **Commit Changes**: After successful task completion, commit with proper message format
+
+7. **Continue Workflow**: After committing:
    - Check status again with `reviewtask status`
    - **If all tasks are completed (no todo, doing, or pending tasks remaining)**: Stop here - all work is done!
    - **If only pending tasks remain**: Handle pending tasks as described in Step 2d
    - **If todo or doing tasks remain**: Repeat this entire workflow from step 1
 
+## Task Classification Guidelines:
+
+**CANCEL** tasks that are:
+- Clear duplicates of already implemented features
+- References to changes already completed in previous commits
+- Obsolete suggestions that no longer apply to current code
+- Tasks that would introduce conflicts with existing implementations
+
+**PENDING** tasks that are:
+- Ambiguous requirements that need clarification
+- Low-priority improvements that could be done later
+- Tasks dependent on external decisions or unclear specifications
+- Enhancements that could be implemented but aren't critical
+
+**TODO** tasks that are:
+- New functional requirements not yet implemented
+- Critical bug fixes or security issues
+- Clear improvement suggestions for current code
+- Tasks with specific actionable requirements
+
+## AI Processing and Task Generation:
+
+The reviewtask tool includes intelligent AI processing that:
+- **Automatic Task Creation**: Analyzes PR review comments and automatically generates actionable tasks
+- **Task Deduplication**: Identifies and removes duplicate or similar tasks to avoid redundant work  
+- **Priority Assignment**: Automatically assigns priority levels based on comment content and context
+- **Task Validation**: Ensures generated tasks are actionable and properly scoped
+
+## Task Completion Verification:
+
+The tool includes verification capabilities to ensure task quality before completion:
+
+**Verification Types:**
+- **Build Verification**: Runs build/compile checks (default: `go build ./...`)
+- **Test Execution**: Runs test suites (default: `go test ./...`)
+- **Code Quality**: Lint and format checks (default: `golangci-lint run`, `gofmt -l .`)
+- **Custom Verification**: Project-specific commands based on task type
+
+**Task Type Detection:**
+Tasks are automatically categorized for custom verification:
+- `test-task`: Tasks containing "test" or "testing"
+- `build-task`: Tasks containing "build" or "compile"
+- `style-task`: Tasks containing "lint" or "format"
+- `bug-fix`: Tasks containing "bug" or "fix"
+- `feature-task`: Tasks containing "feature" or "implement"
+- `general-task`: All other tasks
+
+**Configuration:**
+- `reviewtask config show` - View current verification settings
+- `reviewtask config set-verifier <task-type> <command>` - Set custom verification commands
+- Verification settings stored in `.pr-review/config.json`
+
+## Current Tool Features:
+
+This workflow leverages the full capabilities of the current reviewtask implementation:
+- **Multi-source Authentication**: Supports GitHub CLI, environment variables, and configuration files
+- **Task Management**: Complete lifecycle management with status tracking and validation
+- **Task Completion Verification**: Automated verification checks before task completion
+- **AI-Enhanced Analysis**: Intelligent task generation and classification
+- **Progress Tracking**: Comprehensive status reporting and workflow optimization
+
 ## Important Notes:
 - Work only in the current branch
 - Always verify status changes before proceeding
 - Include proper commit message format with task details and comment references
-- **Task Priority**: Always work on `doing` tasks first, then `todo` tasks, then handle `pending` tasks
+- **Task Priority**: Always work on `doing` tasks first, then `todo` tasks (by priority level), then handle `pending` tasks
+- **Priority-Based Processing**: Within todo tasks, process critical → high → medium → low priority items
+- **Task Completion Verification**: Use `reviewtask complete <task-id>` for verified completion (recommended)
+- **Verification Failure Handling**: If verification fails, fix issues and retry before completing
+- **Verification Configuration**: Custom verification commands can be set per task type for project-specific requirements
 - **Pending Task Management**: Pending tasks must be resolved by changing status to `doing`, `todo`, or `cancel`
+- **Efficient Task Management**: Classify duplicate/unnecessary tasks as `cancel` and uncertain tasks as `pending` to focus on actionable work
+- **Automatic Task Generation**: The tool intelligently creates tasks from review feedback with appropriate priorities
 - Continue until all tasks are completed or no more actionable tasks remain
 - The initial review fetch is executed only once per command invocation, not during the iterative workflow steps
+
+## Example Tool Output:
+
+Here are examples of actual reviewtask command outputs to demonstrate expected behavior:
+
+**`reviewtask status` output example:**
+```text
+PR Review Tasks Status:
+┌────────┬──────────────────────────────────────────┬──────────┬──────────┐
+│ Status │ Task Description                         │ Priority │ ID       │
+├────────┼──────────────────────────────────────────┼──────────┼──────────┤
+│ doing  │ Add input validation for user data       │ critical │ task-001 │
+│ todo   │ Refactor error handling logic            │ high     │ task-002 │
+│ todo   │ Update documentation for API changes     │ medium   │ task-003 │
+│ pending│ Consider alternative data structure      │ low      │ task-004 │
+└────────┴──────────────────────────────────────────┴──────────┴──────────┘
+
+Next recommended task: task-001 (doing - critical priority)
+```
+
+**`reviewtask show` output example:**
+```text
+Task ID: task-001
+Status: doing
+Priority: critical
+Implementation: Implemented
+Verification: Verified
+Description: Add input validation for user data
+
+Original Review Comment:
+"The function doesn't validate input parameters, which could lead to security vulnerabilities."
+
+Comment ID: r123456789
+Review URL: https://github.com/owner/repo/pull/42#discussion_r123456789
+
+Files to modify:
+- src/handlers/user.go
+- test/handlers/user_test.go
+
+Last Verification: 2025-08-01 18:19:53
+Verification History:
+  1. PASSED 2025-08-01 18:19:53 (checks: build, test)
+```
+
+**`reviewtask verify` output example:**
+```text
+Running verification checks for task 'task-001'...
+
+BUILD: verification passed (0.45s)
+TEST: verification passed (2.3s)
+
+All verification checks passed for task 'task-001'
+You can now safely complete this task with: reviewtask complete task-001
+```
+
+**`reviewtask complete` output example:**
+```text
+Running verification checks for task 'task-001'...
+Task 'task-001' completed successfully!
+All verification checks passed
+```
 
 Execute this workflow now.

--- a/src/cli/OracleCli.Commands/CommandParser.fs
+++ b/src/cli/OracleCli.Commands/CommandParser.fs
@@ -4,28 +4,24 @@ open OracleCli.Core
 open OracleCli.Commands
 
 /// Parse docs-sign command arguments with exclude patterns and message
-let parseDocsSignArgs (args: string list) : Result<string * string option * string list * bool, string> =
-    let rec loop (path: string option) (message: string option) (excludePatterns: string list) (useClaimsBased: bool) (remaining: string list) =
+let parseDocsSignArgs (args: string list) : Result<string * string option * string list, string> =
+    let rec loop (path: string option) (message: string option) (excludePatterns: string list) (remaining: string list) =
         match remaining with
         | [] ->
             match path with
-            | Some p -> Ok (p, message, List.rev excludePatterns, useClaimsBased)
+            | Some p -> Ok (p, message, List.rev excludePatterns)
             | None -> Error "Path argument required for docs-sign command"
         | "--exclude" :: pattern :: rest -> 
-            loop path message (pattern :: excludePatterns) useClaimsBased rest
+            loop path message (pattern :: excludePatterns) rest
         | "-m" :: msg :: rest ->
-            loop path (Some msg) excludePatterns useClaimsBased rest
-        | "--use-claims" :: rest ->
-            loop path message excludePatterns true rest
-        | "--use-legacy" :: rest ->
-            loop path message excludePatterns false rest
+            loop path (Some msg) excludePatterns rest
         | pathArg :: rest when path.IsNone && not (pathArg.StartsWith("-")) ->
-            loop (Some pathArg) message excludePatterns useClaimsBased rest
+            loop (Some pathArg) message excludePatterns rest
         | pathArg :: _ when pathArg.StartsWith("-") ->
             Error $"Unknown option: {pathArg}"
         | _ -> Error "Invalid arguments for docs-sign command"
     
-    loop None None [] true args
+    loop None None [] args
 
 /// Parse command line arguments into Oracle commands
 let parseCommand (args: string array) : Result<OracleCommand, string> =
@@ -48,8 +44,8 @@ let parseCommand (args: string array) : Result<OracleCommand, string> =
         Ok (Ask (Query query))
     | "docs-sign" :: rest ->
         match parseDocsSignArgs rest with
-        | Ok (path, message, excludePatterns, useClaimsBased) ->
-            Ok (DocsSign (path, message, excludePatterns, useClaimsBased))
+        | Ok (path, message, excludePatterns) ->
+            Ok (DocsSign (path, message, excludePatterns))
         | Error err -> Error err
     | "help" :: [] | "--help" :: [] | "-h" :: [] ->
         Ok Help
@@ -68,7 +64,7 @@ COMMANDS:
     list [--tag <tag>]             List specifications, optionally filtered by tag
     watch <code>                   Watch code file for changes and validate
     ask <question>                 Ask questions about specifications
-    docs-sign <path> [--exclude <pattern>] [-m <message>] [--use-legacy]  Digitally sign file or directory (claim-based by default)
+    docs-sign <path> [--exclude <pattern>] [-m <message>]  Digitally sign file or directory
     help                           Show this help message
 
 EXAMPLES:
@@ -80,7 +76,7 @@ EXAMPLES:
     oracle docs-sign docs/specifications/domain-features/user-auth.md
     oracle docs-sign docs/specifications/ --exclude "*.draft.md" -m "Batch signing"
     oracle docs-sign docs/spec.yaml -m "Security review completed"
-    oracle docs-sign docs/spec.yaml --use-legacy  # Use legacy signature format if needed
+    oracle docs-sign docs/spec.yaml  # Generate claim-based signature
 
 ENVIRONMENT VARIABLES:
     ANTHROPIC_API_KEY             Required for AI features

--- a/src/cli/OracleCli.Commands/CommandTypes.fs
+++ b/src/cli/OracleCli.Commands/CommandTypes.fs
@@ -11,7 +11,7 @@ type OracleCommand =
     | ListSpecs of tag: string option
     | Watch of CodePath
     | Ask of Query
-    | DocsSign of string * string option * exclude: string list * useClaimsBased: bool
+    | DocsSign of string * string option * exclude: string list
     | Help
 
 /// Command execution context

--- a/src/cli/OracleCli.Services/ClaimBasedSigningService.fs
+++ b/src/cli/OracleCli.Services/ClaimBasedSigningService.fs
@@ -47,8 +47,12 @@ let getSignerFromGitConfig (workingDir: string) : Result<SignerInfo, string> =
             Role = name
             SigningReason = "Digital signature for specification integrity"
         }
-    | Error emailErr, _ -> Error $"Failed to get user.email: {emailErr}"
-    | _, Error nameErr -> Error $"Failed to get user.name: {nameErr}"
+    | Error emailErr, Error nameErr -> 
+        Error $"Failed to get git config: user.email ({emailErr}), user.name ({nameErr})"
+    | Error emailErr, _ -> 
+        Error $"Failed to get user.email: {emailErr}"
+    | _, Error nameErr -> 
+        Error $"Failed to get user.name: {nameErr}"
 
 /// Normalize file path to project root relative path (Unix-style)
 let normalizeToProjectPath (filePath: string) (projectRoot: string) : Result<string, string> =

--- a/src/cli/OracleCli.Services/ClaimBasedSigningService.fs
+++ b/src/cli/OracleCli.Services/ClaimBasedSigningService.fs
@@ -5,8 +5,50 @@ open System.IO
 open System.Text
 open System.Text.Json
 open System.Security.Cryptography
+open System.Diagnostics
 open OracleCli.Core
-// open OracleCli.Services.GitService  // Not needed yet
+
+/// Execute git command safely to get configuration values
+let private executeGitConfig (workingDir: string) (configKey: string) : Result<string, string> =
+    try
+        let startInfo = ProcessStartInfo()
+        startInfo.FileName <- "git"
+        startInfo.ArgumentList.Add("config")
+        startInfo.ArgumentList.Add(configKey)
+        startInfo.WorkingDirectory <- workingDir
+        startInfo.RedirectStandardOutput <- true
+        startInfo.RedirectStandardError <- true
+        startInfo.UseShellExecute <- false
+        startInfo.CreateNoWindow <- true
+        
+        use proc = Process.Start(startInfo)
+        if proc = null then
+            Error "Failed to start git process"
+        else
+            proc.WaitForExit()
+            
+            let output = proc.StandardOutput.ReadToEnd().Trim()
+            let error = proc.StandardError.ReadToEnd().Trim()
+            
+            if proc.ExitCode = 0 && not (String.IsNullOrWhiteSpace(output)) then
+                Ok output
+            else
+                Error $"Git config '{configKey}' not found or empty"
+                
+    with
+    | ex -> Error $"Failed to execute git config: {ex.Message}"
+
+/// Get signer information from git config
+let getSignerFromGitConfig (workingDir: string) : Result<SignerInfo, string> =
+    match executeGitConfig workingDir "user.email", executeGitConfig workingDir "user.name" with
+    | Ok email, Ok name ->
+        Ok {
+            Email = email
+            Role = name
+            SigningReason = "Digital signature for specification integrity"
+        }
+    | Error emailErr, _ -> Error $"Failed to get user.email: {emailErr}"
+    | _, Error nameErr -> Error $"Failed to get user.name: {nameErr}"
 
 /// Normalize file path to project root relative path (Unix-style)
 let normalizeToProjectPath (filePath: string) (projectRoot: string) : Result<string, string> =

--- a/src/cli/OracleCli.Services/GitService.fs
+++ b/src/cli/OracleCli.Services/GitService.fs
@@ -120,32 +120,6 @@ let hasUncommittedChanges (workingDir: string) : Result<bool, string> =
     | Error err -> Error err
 
 /// Get signer information from git config (repository -> global priority)
-let getSignerFromGitConfig (workingDir: string) : Result<SignerInfo, string> =
-    try
-        // Try to get user.email and user.name from git config
-        // Git config automatically handles repository -> global priority
-        match executeGitCommand workingDir "config user.email",
-              executeGitCommand workingDir "config user.name" with
-        | Ok email, Ok name when not (String.IsNullOrWhiteSpace(email)) && not (String.IsNullOrWhiteSpace(name)) ->
-            let signerInfo = {
-                Email = email.Trim()
-                Role = name.Trim()  // Use git user.name as role
-                SigningReason = "Document approval"
-            }
-            Ok signerInfo
-        | Ok email, Ok name ->
-            let missing = 
-                [if String.IsNullOrWhiteSpace(email) then "user.email"
-                 if String.IsNullOrWhiteSpace(name) then "user.name"]
-                |> String.concat ", "
-            Error $"Git config missing: {missing}. Please configure with 'git config user.email <email>' and 'git config user.name <name>'"
-        | Error emailErr, _ ->
-            Error $"Failed to get user.email from git config: {emailErr}"
-        | _, Error nameErr ->
-            Error $"Failed to get user.name from git config: {nameErr}"
-    with
-    | ex -> Error $"Git config access failed: {ex.Message}"
-
 /// Get git repository root directory
 let getGitRootDirectory (startPath: string) : Result<string, string> =
     let rec findGitRoot (currentPath: string) =

--- a/src/cli/OracleCli.Tests/DocsSignIntegrationTests.fs
+++ b/src/cli/OracleCli.Tests/DocsSignIntegrationTests.fs
@@ -20,7 +20,7 @@ let ``parseCommand should parse docs-sign command with default signer`` () =
     
     // Assert
     match result with
-    | Ok (DocsSign (path, customMessage, excludePatterns, true)) ->
+    | Ok (DocsSign (path, customMessage, excludePatterns)) ->
         Assert.Equal("test.yaml", path)
         // Custom message should be None for basic command
         Assert.True customMessage.IsNone
@@ -38,7 +38,7 @@ let ``parseCommand should parse docs-sign command with custom message`` () =
     
     // Assert
     match result with
-    | Ok (DocsSign (path, customMessage, excludePatterns, true)) ->
+    | Ok (DocsSign (path, customMessage, excludePatterns)) ->
         Assert.Equal("test.yaml", path)
         // Custom message should be present
         Assert.True customMessage.IsSome
@@ -57,7 +57,7 @@ let ``parseCommand should parse docs-sign command with exclude patterns`` () =
     
     // Assert
     match result with
-    | Ok (DocsSign (path, customMessage, excludePatterns, true)) ->
+    | Ok (DocsSign (path, customMessage, excludePatterns)) ->
         Assert.Equal("docs/", path)
         Assert.True customMessage.IsNone
         Assert.Equal(2, excludePatterns.Length)
@@ -75,7 +75,7 @@ let ``parseCommand should parse docs-sign command with both exclude and message`
     
     // Assert
     match result with
-    | Ok (DocsSign (path, customMessage, excludePatterns, true)) ->
+    | Ok (DocsSign (path, customMessage, excludePatterns)) ->
         Assert.Equal("docs/", path)
         Assert.True customMessage.IsSome
         Assert.Equal("Batch signing", customMessage.Value)

--- a/src/cli/OracleCli.Tests/ServiceIntegrationTests.fs
+++ b/src/cli/OracleCli.Tests/ServiceIntegrationTests.fs
@@ -322,7 +322,7 @@ let ``Service integration should work with all command types`` () =
             | None -> Assert.True(true)
         | Watch (CodePath cp) -> Assert.NotEmpty(cp)
         | Ask (Query q) -> Assert.NotEmpty(q)
-        | DocsSign (path, _customMessage, _excludePatterns, false) -> 
+        | DocsSign (path, _customMessage, _excludePatterns) -> 
             Assert.NotEmpty(path)
             // customMessage and excludePatterns can be None/empty or Some/present
         | Help -> Assert.True(true)

--- a/src/cli/OracleCli/Program.fs
+++ b/src/cli/OracleCli/Program.fs
@@ -73,7 +73,7 @@ let executeOracleCommand (config: ServiceConfig) (command: OracleCommand) : Resu
     | Help -> 
         handleHelp ()
         Ok ()
-    | DocsSign (_path, _customMessage, _excludePatterns, _useClaimsBased) ->
+    | DocsSign (_path, _customMessage, _excludePatterns) ->
         match executeCommandWithValidation context command with
         | Ok message ->
             printfn "%s" message


### PR DESCRIPTION
## Summary

- レガシー署名システムの完全削除を実装
- `--use-legacy`オプションと関連パラメータの削除  
- クレームベース署名のみに統一してアーキテクチャを簡素化

## 主な変更内容

### 1. コマンドライン引数の簡素化
- `--use-legacy`オプションの削除
- `useClaimsBased`パラメータの削除（常にクレームベース署名を使用）
- `DocsSign`コンストラクタを4パラメータから3パラメータに変更

### 2. 関数の整理とリネーム
- `signSingleFile`（レガシー版）の完全削除
- `signSingleFileWithClaims`を`signSingleFile`にリネーム
- 条件分岐ロジックの削除（常にクレームベース署名）

### 3. Git設定依存の移動
- `GitService.getSignerFromGitConfig`を削除
- `ClaimBasedSigningService`に統合して依存関係を簡素化

### 4. テストコードの更新
- 全テストケースを3パラメータコンストラクタに対応
- レガシー署名テストの削除

## テスト結果

```bash
dotnet build
# Build succeeded with 0 errors (3 warnings only)
```

## アーキテクチャ改善

- 条件分岐の削除により、コードの複雑性が大幅に軽減
- 署名方式が単一化され、保守性が向上
- Git設定依存の統合により、モジュール間の結合度が改善

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The docs-sign command now exclusively uses claim-based digital signing, streamlining the signing process and removing legacy options.
  * Signer information is automatically retrieved from your Git configuration for claim-based signatures.

* **Bug Fixes**
  * Simplified command parsing and improved error messages related to missing Git configuration.

* **Chores**
  * Updated CLI help text and examples to reflect the removal of legacy signing options.
  * Tests and internal logic updated to match the new, simplified command structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->